### PR TITLE
Add a `POST /people` endpoint

### DIFF
--- a/nb2/__init__.py
+++ b/nb2/__init__.py
@@ -12,7 +12,7 @@ from nb2.slackbot import SlackBot
 
 db = SQLAlchemy()
 migrate = Migrate()
-bot = SlackBot(token=os.environ['SLACK_BOT_TOKEN'])
+bot = SlackBot()
 
 
 def create_app(config=Config):
@@ -30,9 +30,10 @@ def create_app(config=Config):
     from nb2 import api
     app.register_blueprint(api.bp)
 
+    token = os.environ['SLACK_BOT_TOKEN']
     signing_secret = os.environ['SLACK_SIGNING_SECRET']
     event_url = os.environ['SLACK_EVENTS_URL']
-    bot.init_app(signing_secret, event_url, app)
+    bot.init_app(token, signing_secret, event_url, app)
 
     # This is somewhat of a hack so that the decorators that
     # register slack event handlers will be run after

--- a/nb2/api.py
+++ b/nb2/api.py
@@ -21,9 +21,10 @@ def get_all_people():
 def create_person():
     data = request.get_json() or {}
     slack_user_id = data.get('slack_user_id')
+    missing_required_fields = set(Person.required_fields) - set(data.keys())
 
-    if not all(field in data for field in Person.required_fields):
-        error_msg = f"Missing required field(s): {', '.join(set(Person.required_fields) - set(data.keys()))}"
+    if missing_required_fields:
+        error_msg = f"Missing required field(s): {', '.join(missing_required_fields)}"
         return validation_error(error_msg)
 
     if Person.query.filter(Person.slack_user_id == slack_user_id).first():

--- a/nb2/api.py
+++ b/nb2/api.py
@@ -1,6 +1,7 @@
-from flask import jsonify, Blueprint
+from flask import Blueprint, jsonify, request
 
 from nb2 import db
+from nb2.errors import conflict, validation_error
 from nb2.models import Person
 
 bp = Blueprint('api', __name__)
@@ -10,6 +11,32 @@ bp = Blueprint('api', __name__)
 def hello():
     return 'Hello'
 
-@bp.route('/people')
+
+@bp.route('/people', methods=['GET'])
 def get_all_people():
     return jsonify([person.serialize() for person in Person.query.all()])
+
+
+@bp.route('/people', methods=['POST'])
+def create_person():
+    data = request.get_json() or {}
+    slack_user_id = data.get('slack_user_id')
+
+    if not all(field in data for field in Person.required_fields):
+        error_msg = f"Missing required field(s): {', '.join(set(Person.required_fields) - set(data.keys()))}"
+        return validation_error(error_msg)
+
+    if Person.query.filter(Person.slack_user_id == slack_user_id).first():
+        error_msg = f"Person with slack_user_id = '{slack_user_id}' already exists"
+        return conflict(error_msg)
+
+    new_person = Person()
+    new_person.deserialize(data)
+    db.session.add(new_person)
+    db.session.commit()
+    db.session.refresh(new_person)
+
+    response = jsonify(new_person.serialize())
+    response.status_code = 201
+
+    return response

--- a/nb2/errors.py
+++ b/nb2/errors.py
@@ -1,0 +1,30 @@
+from flask import jsonify
+
+
+def _error_response(status_code, message):
+    """
+    Helper method for returning an API error response.
+    """
+    payload = {
+        'message': message
+    }
+
+    response = jsonify(payload)
+    response.status_code = status_code
+
+    return response
+
+
+def validation_error(message):
+    """
+    Helper method for raising validation errors with 400 status code.
+    """
+    return _error_response(400, message)
+
+
+def conflict(message):
+    """
+    Helper method for raising conflict errors with 409 status code.
+    """
+    return _error_response(409, message)
+

--- a/nb2/models.py
+++ b/nb2/models.py
@@ -17,6 +17,9 @@ class Person(db.Model):
     last_name = db.Column(db.String(32))
     quotes = db.relationship('Quote', backref='person', lazy=True)
 
+    required_fields = ['slack_user_id', 'first_name']
+    editable_fields = ['slack_user_id', 'first_name', 'last_name']
+
     def __repr__(self):
         return f"<Person: {self.slack_user_id}; Name: {self.first_name}>"
 
@@ -28,6 +31,15 @@ class Person(db.Model):
             'last_name': self.last_name,
             'quotes': [quote.content for quote in self.quotes]
         }
+
+    def deserialize(self, data):
+        """
+        Update the editable fields on a person with `data`.
+        """
+        for field in self.editable_fields:
+            if field in data:
+                setattr(self, field, data[field])
+
 
 class Quote(db.Model):
     """

--- a/nb2/slackbot.py
+++ b/nb2/slackbot.py
@@ -3,11 +3,12 @@ from slackeventsapi import SlackEventAdapter
 
 
 class SlackBot:
-    def __init__(self, token):
-        self.web_client = WebClient(token=token)
+    def __init__(self):
+        self.web_client = None
         self.event_adapter = None
 
-    def init_app(self, signing_secret, event_url, app):
+    def init_app(self, token, signing_secret, event_url, app):
+        self.web_client = WebClient(token=token)
         self.event_adapter = SlackEventAdapter(signing_secret, event_url, app)
 
     def send_text(self, text, channel):

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ jedi==0.17.2
 Jinja2==2.11.2
 Mako==1.1.3
 MarkupSafe==1.1.1
+mixer==6.1.3
 multidict==4.7.6
 parso==0.7.1
 pexpect==4.8.0
@@ -26,6 +27,10 @@ pickleshare==0.7.5
 prompt-toolkit==3.0.6
 ptyprocess==0.6.0
 Pygments==2.6.1
+pytest==6.0.1
+pytest-clarity==0.3.0a0
+pytest-flask==1.0.0
+pytest-sugar==0.9.4
 python-dateutil==2.8.1
 python-dotenv==0.14.0
 python-editor==1.0.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
+import os
+
 import pytest
+from mixer.backend.flask import mixer
 
 from nb2 import create_app
 from nb2 import db as _db
@@ -8,7 +11,14 @@ from config import TestConfig
 @pytest.fixture(scope="session")
 def app(request):
     """Test session-wide test `Flask` application."""
+    os.environ['SLACK_BOT_TOKEN'] = "x"
+    os.environ['SLACK_SIGNING_SECRET'] = "x"
+    os.environ['SLACK_EVENTS_URL'] = "/x/"
+
     app = create_app(TestConfig)
+
+    mixer.init_app(app)
+
     return app
 
 
@@ -22,6 +32,11 @@ def _setup_app_context_for_test(request, app):
     ctx.push()
     yield  # tests will run here
     ctx.pop()
+
+
+@pytest.fixture(scope="session")
+def client(app, request):
+    return app.test_client()
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_person_api.py
+++ b/tests/test_person_api.py
@@ -1,0 +1,80 @@
+import json
+
+import pytest
+from mixer.backend.flask import mixer
+from flask import url_for
+
+from nb2.models import Person
+
+
+@pytest.mark.parametrize('num_people', (0, 2))
+def test_get_all_people(num_people, client, session):
+    mixer.cycle(num_people).blend(Person)
+
+    response = client.get(url_for('api.get_all_people'))
+
+    response_json = response.json
+    assert response.status_code == 200
+    assert len(response_json) == num_people
+
+
+def test_create_person(client, session):
+    data = {
+        "slack_user_id": "foobar",
+        "first_name": "foo",
+        "last_name": "bar"
+    }
+
+    response = client.post(
+        url_for('api.create_person'),
+        data=json.dumps(data),
+        content_type='application/json'
+    )
+
+    response_json = response.json
+    assert response.status_code == 201
+    assert isinstance(response_json.get("id"), int)
+    assert isinstance(response_json.get('quotes'), list)
+    for field, value in data.items():
+        assert response_json.get(field) == value
+
+
+def test_cannot_create_person_with_duplicate_slack_user_id(client, session):
+    existing_person = mixer.blend(Person)
+    data = {
+        "slack_user_id": existing_person.slack_user_id,
+        "first_name": "foo",
+        "last_name": "bar"
+    }
+    expected_error = f"Person with slack_user_id = '{data['slack_user_id']}' already exists"
+
+    response = client.post(
+        url_for('api.create_person'),
+        data=json.dumps(data),
+        content_type='application/json'
+    )
+
+    response_json = response.json
+    assert response.status_code == 409
+    assert response_json.get("message") == expected_error
+
+
+@pytest.mark.parametrize('field', Person.required_fields)
+def test_cannot_create_person_with_duplicate_slack_user_id(field, client, session):
+    data = {
+        "slack_user_id": "foobar",
+        "first_name": "foo",
+        "last_name": "bar"
+    }
+    expected_error = f"Missing required field(s): {field}"
+    data.pop(field)
+
+    response = client.post(
+        url_for('api.create_person'),
+        data=json.dumps(data),
+        content_type='application/json'
+    )
+
+    response_json = response.json
+    assert response.status_code == 400
+    assert response_json.get("message") == expected_error


### PR DESCRIPTION
# Overview

Adds the endpoint to create a new person. It also adds tests for this new endpoint and the existing "get all people" endpoint.

# References

#14 

# Details

`create_person` person validates that all required Person fields are present and that a person matching the provided `slack_user_id` doesn't already exist. It raises 400 and 409 errors for these error cases, respectively. Helper methods were created to generate those error messages. This was done in hopes to make the code more readable by giving a name to the error code and DRY up the message jsonification. 

I added a few pytest dependencies that help clean up the pytest output. I also added [mixer](https://github.com/klen/mixer), which is a library similar to model-bakery. It allows us to easily create instances of objects in tests without having to manually enter the fields. model-bakery is only compatible with Django and mixer is a pretty comparable alternative with better compatibility for Flask. 

When writing the tests, I had to clean up some of the SlackBot code. Since the `SLACK_BOT_TOKEN` lookup occurs at the highest scope in `__init__.py`, it's run just by importing the module before the `conftest.py` file even has a chance to set anything up. I could have added a dotenv dependency for pytets and created a test.env file, but I thought it would be nicer to refactor and prevent the need for `SLACK_BOT_TOKEN` until the `init_app` method on the bot. This way the `app` fixture in `conftest.py` can just add some dummy env variables during setup.