### PR TITLE
Add get person API endpoint

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -10,7 +10,7 @@ paths:
       summary: Returns a list of all Persons with quotes in Nostalgiabot
       responses:
         '200':
-          description: 'Nostalgiabot remembers these people:'
+          description: 'People matching criteria:'
           content:
             application/json:
               schema:
@@ -24,6 +24,59 @@ paths:
       responses:
         '201':
           description: Person added
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Person"
+        '400':
+          description: Missing required fields
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Missing required field(s): first_name, slack_user_id"
+        '409':
+          description: slack_user_id conflict
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Person with slack_user_id W012A3CDE already exists"
+
+  /people/{slack_user_id}:
+    get:
+      summary: Returns a specific Person by their slack_user_id with quotes in Nostalgiabot
+      parameters:
+        - in: path
+          required: true
+          name: slack_user_id
+          description: The unique ID assigned by Slack to a user
+          schema:
+            type: string
+            example: "W012A3CDE"
+      responses:
+        "200":
+          description: "Person matching criteria:"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Person"
+        "404":
+          description: slack_user_id does not exist
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Person with slack_user_id W012A3CDE does not exist"
 
 components:
   schemas:
@@ -42,6 +95,10 @@ components:
         last_name:
           type: string
           example: "Bot"
+        quotes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Quote'
 
     Quote:
       type: object

--- a/nb2/errors.py
+++ b/nb2/errors.py
@@ -22,6 +22,13 @@ def validation_error(message):
     return _error_response(400, message)
 
 
+def does_not_exist_error(message):
+    """
+    Helper method for raising does not exist errors with 404 status code.
+    """
+    return _error_response(404, message)
+
+
 def conflict(message):
     """
     Helper method for raising conflict errors with 409 status code.

--- a/tests/test_person_api.py
+++ b/tests/test_person_api.py
@@ -7,6 +7,16 @@ from flask import url_for
 from nb2.models import Person
 
 
+def get_serialized_person(person):
+    return {
+        "id": person.id,
+        "slack_user_id": person.slack_user_id,
+        "first_name": person.first_name,
+        "last_name": person.last_name,
+        "quotes": person.quotes
+    }
+
+
 @pytest.mark.parametrize('num_people', (0, 2))
 def test_get_all_people(num_people, client, session):
     mixer.cycle(num_people).blend(Person)
@@ -16,6 +26,48 @@ def test_get_all_people(num_people, client, session):
     response_json = response.json
     assert response.status_code == 200
     assert len(response_json) == num_people
+
+
+def test_get_person(client, session):
+    expected_person = mixer.blend(Person)
+    expected_data = get_serialized_person(expected_person)
+
+    response = client.get(url_for('api.get_person', slack_user_id=expected_person.slack_user_id))
+
+    response_json = response.json
+    assert response.status_code == 200
+    assert response_json == expected_data
+
+
+def test_get_correct_person_by_slack_user_id(client, session):
+    expected_person = mixer.blend(Person)
+    other_person = mixer.blend(Person)
+    expected_data = get_serialized_person(expected_person)
+
+    assert expected_person.id != other_person.id and expected_person.slack_user_id != other_person.slack_user_id
+
+    response = client.get(url_for('api.get_person', slack_user_id=expected_person.slack_user_id))
+
+    response_json = response.json
+    assert response.status_code == 200
+    assert response_json == expected_data
+
+
+def test_get_person_raises_404_if_person_does_not_exist(client, session):
+    existing_person = mixer.blend(Person)
+    slack_user_id_lookup = mixer.faker.pystr(16)
+
+    # Make sure slack_user_id_lookup doesn't already exist in db
+    while slack_user_id_lookup == existing_person.slack_user_id:
+        slack_user_id_lookup = mixer.faker.pystr(16)
+
+    expected_error = f"Person with slack_user_id {slack_user_id_lookup} does not exist"
+
+    response = client.get(url_for('api.get_person', slack_user_id=slack_user_id_lookup))
+
+    response_json = response.json
+    assert response.status_code == 404
+    assert response_json.get("message") == expected_error
 
 
 def test_create_person(client, session):


### PR DESCRIPTION
## Overview

Implement the get endpoint for a single Person. The identifier used to identify a person is the `slack_user_id`.

## Usage:

In `flask shell` create a person if one doesn't already exist

```
p = Person(first_name="foo", slack_user_id="foobar")
db.session.add(p)
db.session.commit()
```

Start the app and make the following GET request depending on a known existing person's `slack_user_id` (`foobar` is used here).


`GET /person/foobar`

A response similar to the following is expected:

```json
{
  "first_name": "foo",
  "id": 41,
  "last_name": null,
  "quotes": [],
  "slack_user_id": "foobar"
}
```

If an `slack_user_id` is provided that doesn't match any existing user, the following 404 error is returned:
```
{
  "message": "Person with slack_user_id df does not exist"
}
```

## References

resolves #11 