### PR TITLE
Fix in memory db and mixer setup

### DIFF
--- a/config.py
+++ b/config.py
@@ -18,6 +18,5 @@ class DevelopmentConfig(Config):
 
 class TestConfig(Config):
     TESTING = True
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
-        'sqlite:///' + os.path.join(basedir, 'in_memory_test.db')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or 'sqlite:///:memory:'
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,6 @@ def app(request):
 
     app = create_app(TestConfig)
 
-    mixer.init_app(app)
-
     return app
 
 
@@ -58,6 +56,7 @@ def session(app, db, request):
     session = _db.create_scoped_session(options=options)
 
     _db.session = session
+    mixer.init_app(app)
 
     yield session
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,31 @@
+import pytest
+
+from nb2.commands import generate_data
+from nb2.models import Person, Quote
+
+
+@pytest.fixture()
+def cli_runner(app):
+    return app.test_cli_runner()
+
+
+@pytest.mark.parametrize('num_people', ['1', '10'])
+def test_generate_data_creates_num_people(num_people, session, cli_runner):
+    # Set quotes to 1 since quotes aren't being tested here
+    num_quotes = '1'
+
+    result = cli_runner.invoke(generate_data, [num_people, num_quotes])
+
+    assert result.exit_code == 0  # success
+    assert Person.query.count() == int(num_people)
+
+
+@pytest.mark.parametrize('num_quotes', ['1', '10'])
+def test_generate_data_creates_num_quotes(num_quotes, session, cli_runner):
+    # Set people to 1 since people aren't being tested here
+    num_people = '1'
+
+    result = cli_runner.invoke(generate_data, [num_people, num_quotes])
+
+    assert result.exit_code == 0  # success
+    assert Quote.query.count() == int(num_quotes)


### PR DESCRIPTION
- [x] Fix the db used in tests to be an actual in-memory db.

- [x] Move mixer to be initialized per session to fix tests failing when not clearing the db data correctly 
