### PR TITLE
Use flask-restful

### DIFF
--- a/nb2/api.py
+++ b/nb2/api.py
@@ -1,86 +1,173 @@
-from flask import Blueprint, jsonify, request
+from flask import Blueprint
+from flask_restful import abort, Api, fields, marshal, reqparse, Resource
+from sqlalchemy.exc import IntegrityError
 
-from nb2 import db
-from nb2.errors import conflict, does_not_exist_error, validation_error
 from nb2.models import Person, Quote
-from nb2.validators import Validators
-
-bp = Blueprint('api', __name__)
 
 
-@bp.route('/')
-def hello():
-    return 'Hello'
+bp = Blueprint("api", __name__)
+api = Api(bp)
 
 
-@bp.route('/people', methods=['GET'])
-def get_all_people():
-    return jsonify([person.serialize() for person in Person.query.all()])
+class IncludeFilterMixin:
+
+    def __init__(self, *args, **kwargs):
+        if not hasattr(self, 'fields'):
+            self.fields = {}
+
+        if not hasattr(self, 'parser'):
+            self.parser = reqparse.RequestParser(bundle_errors=True)
+
+        self.parser.add_argument('include', type=str, location='args')
+
+        self.include_fields()
+        super(IncludeFilterMixin, self).__init__(*args, **kwargs)
+
+    def include_fields(self):
+        parsed_args = self.parser.parse_args()
+        include_fields = parsed_args['include'] or []
+
+        if include_fields:
+            include_fields = include_fields.split(',')
+
+        for field in include_fields:
+            field_type = getattr(self, f"get_{field}_field_type", None)
+
+            if field_type:
+                self.fields[field] = field_type
 
 
-@bp.route('/people/<slack_user_id>', methods=['GET'])
-def get_person(slack_user_id):
-    person = Person.query.filter_by(slack_user_id=slack_user_id).first()
+class PersonResourceBase(Resource):
 
-    if person is None:
-        error_msg = f"Person with slack_user_id {slack_user_id} does not exist"
-        return does_not_exist_error(error_msg)
+    def __init__(self, *args, **kwargs):
+        self.fields = {
+            "id": fields.Integer,
+            "slack_user_id": fields.String,
+            "first_name": fields.String,
+            "last_name": fields.String,
+        }
 
-    return jsonify(person.serialize())
+        self.parser = reqparse.RequestParser(bundle_errors=True)
+
+        super(PersonResourceBase, self).__init__(*args, **kwargs)
+
+    @property
+    def get_quotes_field_type(self):
+        return fields.List(fields.String(attribute='content'))
 
 
-@bp.route('/people', methods=['POST'])
-def create_person():
-    data = request.get_json() or {}
-    slack_user_id = data.get('slack_user_id')
+class PersonResource(PersonResourceBase, IncludeFilterMixin):
 
-    required_field_errors = Validators.validate_required_fields_are_provided(Person, data)
-    if required_field_errors:
-        return required_field_errors
+    ERRORS = {
+        "does_not_exist": "Person with slack_user_id {slack_user_id} does not exist"
+    }
 
-    if Person.query.filter(Person.slack_user_id == slack_user_id).first():
-        error_msg = f"Person with slack_user_id {slack_user_id} already exists"
-        return conflict(error_msg)
+    def get(self, slack_user_id):
+        person = Person.query.filter_by(slack_user_id=slack_user_id).one_or_none()
 
-    new_person = Person()
-    new_person.deserialize(data)
-    db.session.add(new_person)
-    db.session.commit()
-    db.session.refresh(new_person)
+        if person is None:
+            abort(404, message=self.ERRORS["does_not_exist"].format(slack_user_id=slack_user_id))
 
-    response = jsonify(new_person.serialize())
-    response.status_code = 201
+        return marshal(person, self.fields), 200
 
-    return response
 
-@bp.route('/quotes', methods=['POST'])
-def create_quote():
-    data = request.get_json() or {}
-    slack_user_id = data.get('slack_user_id')
+class PersonListResource(PersonResourceBase, IncludeFilterMixin):
 
-    required_field_errors = Validators.validate_required_fields_are_provided(Quote, data)
-    if required_field_errors:
-        return required_field_errors
+    ERRORS = {
+        "slack_user_id_missing": "slack_user_id is required",
+        "first_name_missing": "first_name is required",
+        "already_exists": "Person with slack_user_id {slack_user_id} already exists"
+    }
 
-    target_person = Person.query.filter(Person.slack_user_id==slack_user_id).one_or_none()
+    def __init__(self, *args, **kwargs):
+        super(PersonListResource, self).__init__(*args, **kwargs)
+        self.parser.add_argument(
+            "slack_user_id",
+            dest="slack_user_id",
+            required=True,
+            type=str,
+            help=self.ERRORS.get("slack_user_id_missing"),
+        )
+        self.parser.add_argument(
+            "first_name",
+            dest="first_name",
+            required=True,
+            type=str,
+            help=self.ERRORS.get("first_name_missing"),
+        )
+        self.parser.add_argument(
+            "last_name",
+            dest="last_name",
+            type=str,
+        )
 
-    if not target_person:
-        error_msg = f"Can't add a quote to Person with slack_user_id {slack_user_id} " \
-                     "because they don't exist."
-        return validation_error(error_msg)
+    def get(self):
+        people = Person.query.all()
+        return marshal(people, self.fields), 200
 
-    if target_person.has_said(data.get('content')):
-        error_msg = f"The Quote content provided can't be added because it already exists " \
-                     "for this Person."
-        return validation_error(error_msg)
+    def post(self):
+        parsed_args = self.parser.parse_args()
+        slack_user_id = parsed_args.get('slack_user_id')
 
-    new_quote = Quote()
-    new_quote.deserialize(data)
-    db.session.add(new_quote)
-    db.session.commit()
-    db.session.refresh(new_quote)
+        try:
+            new_person = Person.create(parsed_args)
+        except IntegrityError:
+            return abort(409, message=self.ERRORS.get('already_exists').format(slack_user_id=slack_user_id))
 
-    response = jsonify(new_quote.serialize())
-    response.status_code = 201
+        return marshal(new_person, self.fields), 201
 
-    return response
+
+class QuoteResourceBase(Resource):
+
+    def __init__(self, *args, **kwargs):
+        self.fields = {
+            "id": fields.Integer,
+            "content": fields.String,
+            "person": fields.Integer(),
+            "created": fields.DateTime
+        }
+
+        self.parser = reqparse.RequestParser(bundle_errors=True)
+
+        super(QuoteResourceBase, self).__init__(*args, **kwargs)
+
+    @property
+    def get_quotes_field_type(self):
+        return fields.List(fields.String(attribute='content'))
+
+#
+# @bp.route('/quotes', methods=['POST'])
+# def create_quote():
+#     data = request.get_json() or {}
+#     slack_user_id = data.get('slack_user_id')
+#
+#     required_field_errors = Validators.validate_required_fields_are_provided(Quote, data)
+#     if required_field_errors:
+#         return required_field_errors
+#
+#     target_person = Person.query.filter(Person.slack_user_id==slack_user_id).one_or_none()
+#
+#     if not target_person:
+#         error_msg = f"Can't add a quote to Person with slack_user_id {slack_user_id} " \
+#                      "because they don't exist."
+#         return validation_error(error_msg)
+#
+#     if target_person.has_said(data.get('content')):
+#         error_msg = f"The Quote content provided can't be added because it already exists " \
+#                      "for this Person."
+#         return validation_error(error_msg)
+#
+#     new_quote = Quote()
+#     new_quote.deserialize(data)
+#     db.session.add(new_quote)
+#     db.session.commit()
+#     db.session.refresh(new_quote)
+#
+#     response = jsonify(new_quote.serialize())
+#     response.status_code = 201
+#
+#     return response
+
+
+api.add_resource(PersonListResource, "/people")
+api.add_resource(PersonResource, "/people/<string:slack_user_id>")

--- a/nb2/api.py
+++ b/nb2/api.py
@@ -81,6 +81,7 @@ class PersonListResource(PersonResourceBase, IncludeFilterMixin):
 
     def __init__(self, *args, **kwargs):
         super(PersonListResource, self).__init__(*args, **kwargs)
+
         self.parser.add_argument(
             "slack_user_id",
             dest="slack_user_id",
@@ -123,7 +124,7 @@ class QuoteResourceBase(Resource):
         self.fields = {
             "id": fields.Integer,
             "content": fields.String,
-            "person": fields.Integer(),
+            "person_id": fields.Integer(),
             "created": fields.DateTime
         }
 
@@ -131,43 +132,50 @@ class QuoteResourceBase(Resource):
 
         super(QuoteResourceBase, self).__init__(*args, **kwargs)
 
-    @property
-    def get_quotes_field_type(self):
-        return fields.List(fields.String(attribute='content'))
 
-#
-# @bp.route('/quotes', methods=['POST'])
-# def create_quote():
-#     data = request.get_json() or {}
-#     slack_user_id = data.get('slack_user_id')
-#
-#     required_field_errors = Validators.validate_required_fields_are_provided(Quote, data)
-#     if required_field_errors:
-#         return required_field_errors
-#
-#     target_person = Person.query.filter(Person.slack_user_id==slack_user_id).one_or_none()
-#
-#     if not target_person:
-#         error_msg = f"Can't add a quote to Person with slack_user_id {slack_user_id} " \
-#                      "because they don't exist."
-#         return validation_error(error_msg)
-#
-#     if target_person.has_said(data.get('content')):
-#         error_msg = f"The Quote content provided can't be added because it already exists " \
-#                      "for this Person."
-#         return validation_error(error_msg)
-#
-#     new_quote = Quote()
-#     new_quote.deserialize(data)
-#     db.session.add(new_quote)
-#     db.session.commit()
-#     db.session.refresh(new_quote)
-#
-#     response = jsonify(new_quote.serialize())
-#     response.status_code = 201
-#
-#     return response
+class QuoteListResource(QuoteResourceBase):
+    ERRORS = {
+        "slack_user_id_missing": "slack_user_id is required",
+        "content_missing": "content is required",
+        "person_does_not_exist": "Can't add a quote to Person with slack_user_id {slack_user_id} because they don't exist.",
+        "already_exists": "The Quote content provided can't be added because it already exists for this Person."
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(QuoteListResource, self).__init__(*args, **kwargs)
+
+        self.parser.add_argument(
+            "slack_user_id",
+            dest="slack_user_id",
+            required=True,
+            type=str,
+            help=self.ERRORS.get("slack_user_id_missing"),
+        )
+        self.parser.add_argument(
+            "content",
+            dest="content",
+            required=True,
+            type=str,
+            help=self.ERRORS.get("content_missing"),
+        )
+
+    def post(self):
+        parsed_args = self.parser.parse_args()
+        slack_user_id = parsed_args.get('slack_user_id')
+
+        target_person = Person.query.filter(Person.slack_user_id == slack_user_id).one_or_none()
+
+        if not target_person:
+            return abort(400, message=self.ERRORS.get('person_does_not_exist').format(slack_user_id=slack_user_id))
+
+        if target_person.has_said(parsed_args.get('content')):
+            return abort(400, message=self.ERRORS.get('already_exists').format(slack_user_id=slack_user_id))
+
+        new_quote = Quote.create(parsed_args)
+
+        return marshal(new_quote, self.fields), 201
 
 
 api.add_resource(PersonListResource, "/people")
 api.add_resource(PersonResource, "/people/<string:slack_user_id>")
+api.add_resource(QuoteListResource, "/quotes")

--- a/nb2/models.py
+++ b/nb2/models.py
@@ -19,9 +19,6 @@ class Person(db.Model):
     last_name = db.Column(db.String(32))
     quotes = db.relationship('Quote', backref='person', lazy=True)
 
-    required_fields = ['slack_user_id', 'first_name']
-    editable_fields = ['slack_user_id', 'first_name', 'last_name']
-
     def __repr__(self):
         return f"<Person: {self.slack_user_id} | Name: {self.first_name} | Id: {self.id}>"
 
@@ -31,9 +28,9 @@ class Person(db.Model):
         Update the editable fields on a person with `data`.
         """
         new_person = Person()
-        for field in Person.editable_fields:
-            if field in data:
-                setattr(new_person, field, data[field])
+        new_person.slack_user_id = data['slack_user_id']
+        new_person.first_name = data['first_name']
+        new_person.last_name = data['last_name']
 
         db.session.add(new_person)
         db.session.commit()
@@ -69,9 +66,6 @@ class Quote(db.Model):
     )
     created = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
 
-    required_fields = ['slack_user_id', 'content']
-    editable_fields = ['content']
-
     def __repr__(self):
         return f"<Quote: {self.content} | Id: {self.id}>"
 
@@ -84,6 +78,7 @@ class Quote(db.Model):
         new_quote = Quote()
         new_quote.content = data['content']
         new_quote.person_id = person_id
+
         db.session.add(new_quote)
         db.session.commit()
         db.session.refresh(new_quote)

--- a/nb2/models.py
+++ b/nb2/models.py
@@ -25,22 +25,21 @@ class Person(db.Model):
     def __repr__(self):
         return f"<Person: {self.slack_user_id} | Name: {self.first_name} | Id: {self.id}>"
 
-    def serialize(self):
-        return {
-            'id': self.id,
-            'slack_user_id': self.slack_user_id,
-            'first_name': self.first_name,
-            'last_name': self.last_name,
-            'quotes': [quote.content for quote in self.quotes]
-        }
-
-    def deserialize(self, data):
+    @staticmethod
+    def create(data):
         """
         Update the editable fields on a person with `data`.
         """
-        for field in self.editable_fields:
+        new_person = Person()
+        for field in Person.editable_fields:
             if field in data:
-                setattr(self, field, data[field])
+                setattr(new_person, field, data[field])
+
+        db.session.add(new_person)
+        db.session.commit()
+        db.session.refresh(new_person)
+
+        return new_person
 
     def has_said(self, quote:str) -> bool:
         """


### PR DESCRIPTION
# Overview

Convert API to use flask-restful.

# Tasks

- [x] Convert `/people` endpoint to flask-restful
  - [x] Maintain required fields
  - [x] Maintain existing validation
  - [x] Fix tests
- [x] Convert `/quotes` endpoint to flask-restful
  - [x] Maintain required fields
  - [x] Maintain existing validation
  - [x] Fix tests
- [x] Add `include` query param for quotes
- [ ] Add tests for `include` query param
- [ ] Update API docs

# References

resolves #49