### PR TITLE
Add quotes as an include filter to Person api

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -2,12 +2,21 @@ openapi: 3.0.0
 info:
   title: Nostalgiabot 2 API
   description: Specs for the Nostalgiabot 2 API
-  version: 0.1
+  version: "0.1"
 
 paths:
   /people:
     get:
       summary: Returns a list of all Persons with quotes in Nostalgiabot
+      parameters:
+        - in: query
+          name: include
+          schema:
+            nullable: true
+            type: string
+          description: Used to include the optional field `quotes`
+          example: "include=quotes"
+
       responses:
         '200':
           description: 'People matching criteria:'
@@ -16,7 +25,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Person"
+                  oneOf:
+                    - $ref: "#/components/schemas/Person"
+                    - $ref: "#/components/schemas/PersonWithQuotes"
     post:
       summary: Add a Person to Nostalgiabot's memory
       requestBody:
@@ -60,13 +71,22 @@ paths:
           schema:
             type: string
             example: "W012A3CDE"
+        - in: query
+          name: include
+          schema:
+            nullable: true
+            type: string
+          description: Used to include the optional field `quotes`
+          example: "include=quotes"
       responses:
         "200":
           description: "Person matching criteria:"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Person"
+                oneOf:
+                  - $ref: "#/components/schemas/Person"
+                  - $ref: "#/components/schemas/PersonWithQuotes"
         "404":
           description: slack_user_id does not exist
           content:
@@ -95,10 +115,27 @@ components:
         last_name:
           type: string
           example: "Bot"
+
+    PersonWithQuotes:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        slack_user_id:
+          type: string
+          example: "W012A3CDE"
+        first_name:
+          type: string
+          example: "Nostalgia"
+        last_name:
+          type: string
+          example: "Bot"
         quotes:
           type: array
           items:
-            $ref: '#/components/schemas/Quote'
+            type: string
+            example: "Lorem ipsum dolor sit amet."
 
     Quote:
       type: object

--- a/nb2/api.py
+++ b/nb2/api.py
@@ -9,22 +9,93 @@ bp = Blueprint("api", __name__)
 api = Api(bp)
 
 
-class PersonResourceBase(Resource):
+class IncludeFilterMixin:
+    """
+    A mixin for optionally including fields in an API response
+
+    To optionally include an API field, the relevant Resource class
+    should inherit from this mixin. The Resource class should then
+    implement a `get_<fieldname>_field_type` property method that
+    returns the type definition of the field to include.
+
+    Example:
+        To optionally include a string field named `foo` implement to following
+        on the appropriate Resource class
+
+        @property
+        def get_foo_field_type(self):
+            return fields.String
+
+        See flask-restful docs for defining field types
+        https://flask-restful.readthedocs.io/en/latest/fields.html#basic-usage
+
+    To include these the fields in the api response, add the query parameter
+    `include=fieldname`. Multiple fieldnames are allowed as well:
+    `include=fieldname,fieldname,fieldname`.
+
+    Note that this mixin will modify or create `self.field` and `self.parser`
+    properties on the class.
+    """
+
+    def __init__(self, *args, **kwargs):
+        if not hasattr(self, 'fields'):
+            self.fields = {}
+
+        if not hasattr(self, 'parser'):
+            self.parser = reqparse.RequestParser(bundle_errors=True)
+
+        self.parser.add_argument('include', type=str, location='args')
+
+        self.include_fields()
+        super(IncludeFilterMixin, self).__init__(*args, **kwargs)
+
+    def include_fields(self):
+        parsed_args = self.parser.parse_args()
+        include_fields = parsed_args['include'] or []
+
+        if include_fields:
+            include_fields = include_fields.split(',')
+
+        for field in include_fields:
+            field_type = getattr(self, f"get_{field}_field_type", None)
+
+            if field_type:
+                self.fields[field] = field_type
+
+
+class PersonResourceBase(Resource, IncludeFilterMixin):
+    """
+    A base class for the Person resource to define common properties and methods.
+
+    This class defines a `get_quotes_field_type` method that will allow
+    all Resources that inherit from it to optionally include a `quotes` field
+    in the response.
+    """
+
     def __init__(self, *args, **kwargs):
         self.fields = {
             "id": fields.Integer,
             "slack_user_id": fields.String,
             "first_name": fields.String,
             "last_name": fields.String,
-            "quotes": fields.List(fields.String(attribute="content")),
         }
 
         self.parser = reqparse.RequestParser(bundle_errors=True)
 
         super().__init__(*args, **kwargs)
 
+    @property
+    def get_quotes_field_type(self):
+        return fields.List(fields.String(attribute="content"))
+
 
 class PersonResource(PersonResourceBase):
+    """
+    Implements the API methods for operating on a single Person.
+
+    The `get` method is implemented to fetch a specific
+    person by a `slack_user_id`.
+    """
 
     ERRORS = {
         "does_not_exist":
@@ -41,13 +112,20 @@ class PersonResource(PersonResourceBase):
                 404,
                 message=self.ERRORS["does_not_exist"].format(
                     slack_user_id=slack_user_id
-                ),
+                )
             )
 
         return marshal(person, self.fields), 200
 
 
 class PersonListResource(PersonResourceBase):
+    """
+    Implements the API methods for operating on multiple Persons.
+
+    The `get` method is implemented to fetch all people.
+
+    The `post` method is implemented to create a new Person.
+    """
 
     ERRORS = {
         "slack_user_id_missing": "slack_user_id is required",
@@ -101,6 +179,10 @@ class PersonListResource(PersonResourceBase):
 
 
 class QuoteResourceBase(Resource):
+    """
+    A base class for the Quote resource to define common properties and methods.
+    """
+
     def __init__(self, *args, **kwargs):
         self.fields = {
             "id": fields.Integer,
@@ -115,6 +197,12 @@ class QuoteResourceBase(Resource):
 
 
 class QuoteListResource(QuoteResourceBase):
+    """
+    Implements the API methods for operating on multiple Quotes.
+
+    The `post` method is implemented to create a new Quote.
+    """
+
     ERRORS = {
         "slack_user_id_missing": "slack_user_id is required",
         "content_missing": "content is required",

--- a/tests/test_person_api.py
+++ b/tests/test_person_api.py
@@ -6,20 +6,27 @@ from dateutil.parser import parse
 from mixer.backend.flask import mixer
 from flask import url_for
 
-from nb2.models import Person
+from nb2.models import Person, Quote
 
 
-def get_serialized_person(person):
-    return {
+def get_serialized_person(person, include_quotes=False):
+    data = {
         "id": person.id,
         "slack_user_id": person.slack_user_id,
         "first_name": person.first_name,
         "last_name": person.last_name,
-        "quotes": person.quotes
     }
 
+    if include_quotes:
+        data.update({
+            "quotes": [quote.content for quote in person.quotes]
+        })
+
+    return data
+
+
 @pytest.fixture()
-def prepared_user():
+def prepared_user(client, session):
     return mixer.blend(Person)
 
 
@@ -34,25 +41,64 @@ def test_get_all_people(num_people, client, session):
     assert len(response_json) == num_people
 
 
-def test_get_person(client, session):
-    expected_person = mixer.blend(Person)
-    expected_data = get_serialized_person(expected_person)
+@pytest.mark.parametrize('num_quotes', (0, 2))
+def test_get_all_people_with_quotes(num_quotes, client, session):
+    person1, person2 = mixer.cycle(2).blend(Person)
+    mixer.cycle(num_quotes).blend(Quote, person=person1)
+    mixer.cycle(num_quotes).blend(Quote, person=person2)
+    expected_result = [
+        get_serialized_person(person, include_quotes=True)
+        for person in (person1, person2)
+    ]
 
-    response = client.get(url_for('api.personresource', slack_user_id=expected_person.slack_user_id))
+    response = client.get(url_for('api.personlistresource', include="quotes"))
+
+    response_json = response.json
+    assert response.status_code == 200
+    assert response_json == expected_result
+
+
+def test_get_person(prepared_user, client, session):
+    expected_data = get_serialized_person(prepared_user)
+
+    response = client.get(
+        url_for('api.personresource', slack_user_id=prepared_user.slack_user_id)
+    )
 
     response_json = response.json
     assert response.status_code == 200
     assert response_json == expected_data
 
 
-def test_get_correct_person_by_slack_user_id(client, session):
-    expected_person = mixer.blend(Person)
+@pytest.mark.parametrize('num_quotes', (0, 2))
+def test_get_person_with_quotes(prepared_user, num_quotes, client, session):
+    mixer.cycle(num_quotes).blend(Quote, person=prepared_user)
+    expected_result = get_serialized_person(prepared_user, include_quotes=True)
+
+    response = client.get(
+        url_for('api.personresource',
+                slack_user_id=prepared_user.slack_user_id,
+                include="quotes"
+                )
+    )
+
+    response_json = response.json
+    assert response.status_code == 200
+    assert response_json == expected_result
+
+
+def test_get_correct_person_by_slack_user_id(prepared_user, client, session):
     other_person = mixer.blend(Person)
-    expected_data = get_serialized_person(expected_person)
+    expected_data = get_serialized_person(prepared_user)
 
-    assert expected_person.id != other_person.id and expected_person.slack_user_id != other_person.slack_user_id
+    assert (
+        prepared_user.id != other_person.id and
+        prepared_user.slack_user_id != other_person.slack_user_id
+    )
 
-    response = client.get(url_for('api.personresource', slack_user_id=expected_person.slack_user_id))
+    response = client.get(
+        url_for('api.personresource', slack_user_id=prepared_user.slack_user_id)
+    )
 
     response_json = response.json
     assert response.status_code == 200
@@ -67,9 +113,13 @@ def test_get_person_raises_404_if_person_does_not_exist(client, session):
     while slack_user_id_lookup == existing_person.slack_user_id:
         slack_user_id_lookup = mixer.faker.pystr(16)
 
-    expected_error = f"Person with slack_user_id {slack_user_id_lookup} does not exist"
+    expected_error = (
+        f"Person with slack_user_id {slack_user_id_lookup} does not exist"
+    )
 
-    response = client.get(url_for('api.personresource', slack_user_id=slack_user_id_lookup))
+    response = client.get(
+        url_for('api.personresource', slack_user_id=slack_user_id_lookup)
+    )
 
     response_json = response.json
     assert response.status_code == 404
@@ -92,7 +142,6 @@ def test_create_person(client, session):
     response_json = response.json
     assert response.status_code == 201
     assert isinstance(response_json.get("id"), int)
-    assert isinstance(response_json.get('quotes'), list)
     for field, value in data.items():
         assert response_json.get(field) == value
 
@@ -104,7 +153,9 @@ def test_cannot_create_person_with_duplicate_slack_user_id(client, session):
         "first_name": "foo",
         "last_name": "bar"
     }
-    expected_error = f"Person with slack_user_id {data['slack_user_id']} already exists"
+    expected_error = (
+        f"Person with slack_user_id {data['slack_user_id']} already exists"
+    )
 
     response = client.post(
         url_for('api.personlistresource'),


### PR DESCRIPTION
# Overview

Add the ability to optionally include the `quotes` field for the `/people` endpoint

# Tasks
- [x] Improve ordering of API response (was completed in #43 )
- [x] Add mixin to support include filters
- [x] Add `include` query param for `quotes`
- [x] Add tests for `include` query param
- [x] Update API docs

I also included some clean up in this PR, like adding docstrings and making use of the `prepared_user` in tests.

# References

resolves #27