### PR TITLE
Add isort

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,5 @@
+[settings]
+line_length = 100
+multi_line_output = 3
+include_trailing_comma = True
+known_third_party = alembic,click,dataclasses,dateutil,flask,flask_migrate,flask_restful,flask_sqlalchemy,mixer,pytest,slack,slackeventsapi,sqlalchemy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,12 @@
 repos:
+-   repo: https://github.com/asottile/seed-isort-config
+    rev: v2.2.0
+    hooks:
+    - id: seed-isort-config
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.5.2
+    hooks:
+    - id: isort
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
     hooks:

--- a/requirements/dev
+++ b/requirements/dev
@@ -5,9 +5,11 @@ flake8==3.8.3
 ipdb==0.13.3
 ipython==7.16.1
 ipython-genutils==0.2.0
+isort==5.5.2
 mixer==6.1.3
 pre-commit==2.7.1
 pytest==6.0.1
 pytest-clarity==0.3.0a0
 pytest-flask==1.0.0
 pytest-sugar==0.9.4
+seed-isort-config==2.2.0


### PR DESCRIPTION
# Overview

`isort` is a library that helps auto sort imports we so don't have to do it manually. Added this to the `pre-commit` pipeline.
`seed-isort-config` automatically fills the config file with the third party libraries we're using so they can be sorted together.

To test, modify a file with imports that aren't sorted correctly (currently `nb/__init__.py` is an ok option) and add a test commit. Notice that imports have been sorted alphabetically and grouped in order of builtin python, third party library, our project files.

# References

references #59