### PR TITLE
Get User info from Slack

### DIFF
--- a/nb2/bot/slack_events.py
+++ b/nb2/bot/slack_events.py
@@ -15,5 +15,3 @@ def handle_app_mention(payload):
     channel = event.get("channel")
 
     bot.send_text("OH HI!", channel)
-
-

--- a/nb2/bot/slackbot.py
+++ b/nb2/bot/slackbot.py
@@ -16,3 +16,15 @@ class SlackBot:
 
     def send_blocks(self, blocks, channel):
         self.web_client.chat_postMessage(blocks=blocks, channel=channel)
+
+    def get_user_info(self, slack_user_id: str):
+        """
+        Return Slack's representation of a user with id slack_user_id.
+
+        Args:
+            slack_user_id: string representing the Person's primary Slack id.
+
+        Returns:
+            {} containing Slack user information.
+        """
+        return self.web_client.users_info(user=slack_user_id).data["user"]

--- a/nb2/service/slack_service.py
+++ b/nb2/service/slack_service.py
@@ -1,0 +1,23 @@
+import re
+
+
+def get_target_slack_user_ids(command: str) -> [str]:
+    """
+    Parse a command string that targets one or multiple slack users for
+    those target slack users' ids.
+
+    e.g.
+    "Do something to <@foobar>" -> ["foobar"]
+    "Converse <@a> <@b> <@c>!" -> ["a", "b", "c"]
+
+    Args:
+        - command: string representing a command intending to perform an
+                   action on a target slack user or users.
+
+    Returns:
+        List of strings contining the target slack users' slack_user_ids.
+    """
+    # Matches everything between a <@ and a >
+    # noise!@#<@target>123 -> target
+    slack_user_id_pattern = "(?<=<@)(.*?)(?=>)"
+    return [user_id.group() for user_id in re.finditer(slack_user_id_pattern, command)]

--- a/requirements/dev
+++ b/requirements/dev
@@ -11,5 +11,6 @@ pre-commit==2.7.1
 pytest==6.0.1
 pytest-clarity==0.3.0a0
 pytest-flask==1.0.0
+pytest-mock==3.3.1
 pytest-sugar==0.9.4
 seed-isort-config==2.2.0

--- a/tests/service/test_slack_service.py
+++ b/tests/service/test_slack_service.py
@@ -1,0 +1,7 @@
+from nb2.service.slack_service import get_target_slack_user_ids
+
+
+def test_get_target_slack_user_ids(client, session):
+    command_string = "Yada Yada <@foo>, &#<@emin>, @gotcha, and <@U123>!"
+    expected = ["foo", "emin", "U123"]
+    assert get_target_slack_user_ids(command_string) == expected


### PR DESCRIPTION
# Overview
This MR implements methods that can be used to retrieve user information from Slack. This can be used to fill in fields required to create a `Person` object.

# References
[NB-63](https://github.com/revangel/nostalgiabot2/issues/63)