### PR TITLE
Remember

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,13 +12,13 @@ repos:
     hooks:
     - id: trailing-whitespace
       exclude: migrations/
--   repo: https://gitlab.com/pycqa/flake8
-    rev: '3.8.3'
-    hooks:
-    -   id: flake8
-        exclude: migrations/
 -   repo: https://github.com/ambv/black
     rev: stable
     hooks:
     - id: black
       language_version: python3.6
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: '3.8.3'
+    hooks:
+    -   id: flake8
+        exclude: migrations/

--- a/nb2/__init__.py
+++ b/nb2/__init__.py
@@ -6,10 +6,16 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 
 from config import DevelopmentConfig
-from nb2.bot.slackbot import SlackBot
 
 db = SQLAlchemy()
 migrate = Migrate()
+
+# This import needs to come after db since the import chain
+# in SlackBot eventually imports Person, which needs an
+# instantiated db.
+# TODO: Find a better way to handle circular imports?
+from nb2.bot.slackbot import SlackBot  # noqa
+
 bot = SlackBot()
 
 

--- a/nb2/bot/slack_events.py
+++ b/nb2/bot/slack_events.py
@@ -13,5 +13,4 @@ def handle_app_mention(payload):
     """
     event = payload.get("event", {})
     channel = event.get("channel")
-
-    bot.send_text("OH HI!", channel)
+    bot.run_action(payload, channel)

--- a/nb2/bot/slackbot.py
+++ b/nb2/bot/slackbot.py
@@ -1,15 +1,159 @@
+import re
+from collections import namedtuple
+
 from slack import WebClient
 from slackeventsapi import SlackEventAdapter
 
+from nb2.service.dtos import AddQuoteDTO, CreatePersonDTO
+from nb2.service.person_service import create_person, get_person_by_slack_user_id
+from nb2.service.quote_service import add_quote_to_person
+from nb2.service.slack_service import (
+    get_quote_content_from_remember_command,
+    get_user_ids_from_command,
+)
+
 
 class SlackBot:
+    """
+    A class representing Nostalgiabot's interface with Slack.
+    """
+
+    # Container used by Actions to group returned data
+    # Fields:
+    #   ok: (bool) True if the Action succeeded. False otherwise.
+    #   message: (str) text to send back to the Slack client.
+    Result = namedtuple("Result", ["ok", "message"])
+
     def __init__(self):
         self.web_client = None
         self.event_adapter = None
+        self.slack_user_id = None
 
     def init_app(self, token, signing_secret, event_url, app):
         self.web_client = WebClient(token=token)
         self.event_adapter = SlackEventAdapter(signing_secret, event_url, app)
+
+    def _init_bot_slack_user_id(self):
+        """
+        Initialize bot's slack_user_id by fetching it from Slack. This is performed separately
+        outside of init_app() so that a SlackBot instance can be created without the need for
+        a live connection with the Slack API (e.g. for testing purposes).
+        """
+        self.slack_user_id = self.fetch_bot_info().get("user_id")
+
+    def get_bot_slack_user_id(self) -> str:
+        """
+        Return this SlackBot's slack_user_id if it has one, or initialize it
+        if it does not.
+        """
+        if self.slack_user_id is None:
+            self._init_bot_slack_user_id()
+        return self.slack_user_id
+
+    def run_action(self, payload: dict, channel: str):
+        """
+        Parse the user command from the payload from a Slack event response and run the
+        most applicable action inferred from the command.
+
+        Args:
+            payload: dict payload sent by Slack as a response to an event.
+            channel: string denoting the Slack channel where the command was issued.
+        """
+        command = payload.get("event").get("text")
+
+        if self.is_remember_action(command):
+            target_slack_user_ids = [
+                id
+                for id in get_user_ids_from_command(command)
+                if id != self.get_bot_slack_user_id()
+            ]
+
+            if len(target_slack_user_ids) != 1:
+                # TODO: inappropriate amount of target users
+                return
+
+            target_slack_user_id = target_slack_user_ids[0]
+
+            content = get_quote_content_from_remember_command(command)
+
+            result = self.remember(target_slack_user_id, content)
+
+            self.send_text(result.message, channel)
+
+    #############################
+    # Actions
+    #############################
+
+    def remember(self, target_slack_user_id: str, quote: str):
+        """
+        Add quote to a NB's memory of a Person with target_slack_user_id, if they exist.
+        If they don't exist, look up their info and create a new Person in memory first.
+
+        Args:
+            target_slack_user_id: string representing slack user id for Person to insert
+                                  quote into.
+            quote: string representing content of Quote to store.
+
+        Returns:
+            A Result namedtuple.
+        """
+        if not get_person_by_slack_user_id(target_slack_user_id):
+            user_info = self.fetch_user_info(target_slack_user_id)
+            name = user_info.get("name")
+            first_name = name.split()[0]
+
+            create_person_dto = CreatePersonDTO(
+                slack_user_id=target_slack_user_id, first_name=first_name
+            )
+
+            create_person(create_person_dto)
+
+        add_quote_dto = AddQuoteDTO(slack_user_id=target_slack_user_id, content=quote)
+
+        add_quote_to_person(add_quote_dto)
+
+        return self.Result(ok=True, message="Memory stored!")
+
+    #############################
+    # Action matching functions
+    #############################
+
+    def is_remember_action(self, command: str) -> bool:
+        """
+        Return True if the command string indicates a call to NB's "remember" action.
+
+        A valid "remember" action is a command of the form:
+        '<@NB_user_id> remember .* <@target_user_id> said ".*"'
+
+        Notes:
+        - <@NB_user_id> is optional; it may not be present if a command is issued
+          in a DM with the bot.
+        - Only one target user is allowed.
+        - Quote content (".*") must be encapsulated in double quotes.
+        """
+        double_quote_indeces = [i for i in re.finditer('"', command)]
+
+        if len(double_quote_indeces) != 2:
+            # No suitable quote form found
+            return False
+
+        quote_start_index = double_quote_indeces[0].start()
+        action_segment = command[:quote_start_index]
+
+        user_ids_mentioned = get_user_ids_from_command(action_segment)
+
+        target_slack_user_ids = [
+            user_id for user_id in user_ids_mentioned if user_id != self.get_bot_slack_user_id()
+        ]
+
+        if len(target_slack_user_ids) != 1:
+            return False
+
+        return True
+
+    #############################
+    # External Slack Methods
+    #############################
 
     def send_text(self, text, channel):
         self.web_client.chat_postMessage(text=text, channel=channel)
@@ -17,7 +161,13 @@ class SlackBot:
     def send_blocks(self, blocks, channel):
         self.web_client.chat_postMessage(blocks=blocks, channel=channel)
 
-    def get_user_info(self, slack_user_id: str):
+    def fetch_bot_info(self) -> dict:
+        """
+        Return an object containing info about this bot.
+        """
+        return self.web_client.auth_test()
+
+    def fetch_user_info(self, slack_user_id: str) -> dict:
         """
         Return Slack's representation of a user with id slack_user_id.
 

--- a/nb2/service/dtos.py
+++ b/nb2/service/dtos.py
@@ -28,11 +28,12 @@ class CreatePersonDTO(BaseDTO):
         slack_user_id: string representing the Person's primary Slack id.
         first_name: string representing Person's first name.
     """
-    REQUIRED_FIELDS = ['slack_user_id', 'first_name']
+
+    REQUIRED_FIELDS = ["slack_user_id", "first_name"]
 
     slack_user_id: str
     first_name: str
-    last_name: str
+    last_name: str = None
 
 
 @dataclass
@@ -44,5 +45,6 @@ class AddQuoteDTO(BaseDTO):
         slack_user_id: string representing the Person's primary Slack id.
         content: string representing a Quote the Person has said.
     """
+
     slack_user_id: str
     content: str

--- a/nb2/service/slack_service.py
+++ b/nb2/service/slack_service.py
@@ -1,7 +1,7 @@
 import re
 
 
-def get_target_slack_user_ids(command: str) -> [str]:
+def get_user_ids_from_command(command: str) -> [str]:
     """
     Parse a command string that targets one or multiple slack users for
     those target slack users' ids.
@@ -12,7 +12,7 @@ def get_target_slack_user_ids(command: str) -> [str]:
 
     Args:
         - command: string representing a command intending to perform an
-                   action on a target slack user or users.
+                   Action on a target slack user or users.
 
     Returns:
         List of strings contining the target slack users' slack_user_ids.
@@ -21,3 +21,22 @@ def get_target_slack_user_ids(command: str) -> [str]:
     # noise!@#<@target>123 -> target
     slack_user_id_pattern = "(?<=<@)(.*?)(?=>)"
     return [user_id.group() for user_id in re.finditer(slack_user_id_pattern, command)]
+
+
+def get_quote_content_from_remember_command(command: str) -> str:
+    """
+    Parse a command string invoking a "remember" Action and return the content for the
+    Quote to be stored into memory.
+
+    Notes:
+        - A VALID command string for a "remember" Action is of the form:
+          'remember that <@user_id> said "<content>"'
+        - The content must be enclosed in double quotes.
+
+    Args:
+        command: string representing a valid command invoking a "remember" Action.
+
+    Returns:
+        String representing the content of the Quote.
+    """
+    return re.search('(?<=").*(?=")', command).group()

--- a/requirements/core
+++ b/requirements/core
@@ -18,6 +18,7 @@ Jinja2==2.11.2
 Mako==1.1.3
 MarkupSafe==1.1.1
 multidict==4.7.6
+nltk==3.5
 parso==0.7.1
 pexpect==4.8.0
 pickleshare==0.7.5

--- a/tests/bot/test_slackbot.py
+++ b/tests/bot/test_slackbot.py
@@ -1,7 +1,9 @@
+import pytest
 from mixer.backend.flask import mixer
-from slack import WebClient
 
-from nb2 import bot
+from nb2.bot.slackbot import SlackBot
+from nb2.models import Person
+from nb2.service.quote_service import add_quote_to_person  # noqa (linter doesn't see use in patch)
 
 
 class MockSlackResponse:
@@ -9,12 +11,46 @@ class MockSlackResponse:
         self.data = data
 
 
-def test_get_user_info(client, session, mocker):
-    mock_id = mixer.faker.pystr(10)
+@pytest.fixture()
+def mock_bot(mocker):
+    """
+    Bot for tests with a standardized slack_user_id.
+    """
+    mock_bot = SlackBot()
+    mock_bot.slack_user_id = "UB0T"
+    mocker.patch.object(mock_bot, "web_client")
+    return mock_bot
+
+
+def test_init_bot_slack_user_id(client, session, mocker):
+    mock_auth_test_object = {
+        "ok": True,
+        "url": "https://fake.slack.com/",
+        "team": "Fake Workspace",
+        "user": "Nostalgiabot 2",
+        "team_id": "T12345678",
+        "user_id": "U12345678",
+    }
+
+    # Create a sterile instance of SlackBot to ensure the initialization
+    # works properly from a clean slate.
+    mock_bot = SlackBot()
+
+    mocker.patch.object(mock_bot, "web_client")
+    mocker.patch.object(mock_bot.web_client, "auth_test", return_value=mock_auth_test_object)
+
+    mock_bot._init_bot_slack_user_id()
+
+    assert mock_bot.slack_user_id is not None
+    assert mock_bot.slack_user_id == mock_auth_test_object.get("user_id")
+
+
+def test_fetch_user_info(client, session, mock_bot, mocker):
+    mock_slack_user_id = mixer.faker.pystr(10)
     mock_name = mixer.faker.name()
 
     mock_slack_user_object = {
-        "id": mock_id,
+        "id": mock_slack_user_id,
         "team_id": "TFWDXKU4U",
         "name": mock_name,
         "deleted": False,
@@ -54,12 +90,106 @@ def test_get_user_info(client, session, mocker):
 
     mock_response = {"user": mock_slack_user_object}
 
-    mocker.patch.object(WebClient, "users_info", return_value=MockSlackResponse(mock_response))
+    mocker.patch.object(
+        mock_bot.web_client, "users_info", return_value=MockSlackResponse(mock_response)
+    )
 
-    response = bot.get_user_info(mock_id)
+    response = mock_bot.fetch_user_info(mock_slack_user_id)
 
     assert isinstance(response, dict)
-    assert "id" in response
-    assert "name" in response
-    assert response.get("id") == mock_id
+    assert response.get("id") == mock_slack_user_id
     assert response.get("name") == mock_name
+
+
+def test_remember_creates_new_person_if_they_dont_exist(client, session, mock_bot, mocker):
+    mock_slack_user_id = mixer.faker.pystr(10)
+    mock_name = mixer.faker.name()
+
+    assert Person.query.filter(Person.slack_user_id == mock_slack_user_id).one_or_none() is None
+
+    mocker.patch(f"{__name__}.add_quote_to_person")
+    mocker.patch.object(mock_bot, "fetch_user_info", return_value={"name": mock_name})
+
+    mock_bot.remember(mock_slack_user_id, "Test")
+
+    new_person = Person.query.filter(Person.slack_user_id == mock_slack_user_id).one_or_none()
+
+    assert new_person.first_name == mock_name.split()[0]
+
+
+def test_remember_adds_quote_to_existing_person(client, session, mock_bot):
+    mock_slack_user_id = mixer.faker.pystr(10)
+    mock_first_name = mixer.faker.first_name()
+    mock_last_name = mixer.faker.last_name()
+    mock_quote = mixer.faker.sentence()
+
+    session.add(
+        Person(
+            slack_user_id=mock_slack_user_id, first_name=mock_first_name, last_name=mock_last_name
+        )
+    )
+    session.commit()
+
+    new_person = Person.query.filter(Person.slack_user_id == mock_slack_user_id).one_or_none()
+
+    assert len(new_person.quotes) == 0
+
+    mock_bot.remember(mock_slack_user_id, mock_quote)
+
+    # Check that remember did not create a duplicate Person
+    assert Person.query.count() == 1
+
+    assert len(new_person.quotes) == 1
+
+    assert new_person.quotes[0].content == mock_quote
+
+
+def test_is_remember_action_returns_true_on_valid_command(client, session, mock_bot):
+    assert mock_bot.is_remember_action(
+        f'<@{mock_bot.slack_user_id}> remember that <@U1> said "This is a valid remember command!"'
+    )
+    assert mock_bot.is_remember_action(
+        f'<@{mock_bot.slack_user_id}> REMEMBER THAT <@U1> said "This is a valid remember command!"'
+    )
+    assert mock_bot.is_remember_action(
+        f'<@{mock_bot.slack_user_id}> remember when <@U1> said "This is a valid remember command!"'
+    )
+    assert mock_bot.is_remember_action(
+        'remember that <@U1> said "This is a valid remember command!"'
+    )
+    assert mock_bot.is_remember_action(
+        f"<@{mock_bot.slack_user_id}> remember that <@U2> said "
+        '"This is a valid remember command, <@U3>!"'
+    )
+
+    # Technically, anything is allowed between "remember" and the target user.
+    # Might not be allowed in the future?
+    assert mock_bot.is_remember_action(
+        f"<@{mock_bot.slack_user_id}> remember that that guy <@U1> said "
+        '"This is a valid remember command!"'
+    )
+
+
+def test_is_remember_action_returns_false_when_there_are_too_many_target_users(
+    client, session, mock_bot
+):
+    assert not mock_bot.is_remember_action(
+        f"<@{mock_bot.slack_user_id}> remember that <@U1> <@U2> said "
+        '"This is not a valid command, <@0>!"'
+    )
+
+
+def test_is_remember_action_returns_false_when_single_quotes_are_used(client, session, mock_bot):
+    assert not mock_bot.is_remember_action(
+        "<@12345678> remember that <@U11111111> said 'I am using single quotes.'"
+    )
+
+
+def test_is_remember_action_returns_false_if_there_are_no_target_users(client, session, mock_bot):
+    assert not mock_bot.is_remember_action(
+        f'<@{mock_bot.slack_user_id}> remember that said "This is not a valid command, <@0>!"'
+    )
+    assert not mock_bot.is_remember_action(
+        f"<@{mock_bot.slack_user_id}> remember that <U1> said "
+        '"This is not a valid command, <@0>!"'
+    )

--- a/tests/service/test_slack_service.py
+++ b/tests/service/test_slack_service.py
@@ -1,7 +1,18 @@
-from nb2.service.slack_service import get_target_slack_user_ids
+from mixer.backend.flask import mixer
+
+from nb2.service.slack_service import (
+    get_quote_content_from_remember_command,
+    get_user_ids_from_command,
+)
 
 
-def test_get_target_slack_user_ids(client, session):
+def test_get_user_ids_from_command(client, session):
     command_string = "Yada Yada <@foo>, &#<@emin>, @gotcha, and <@U123>!"
     expected = ["foo", "emin", "U123"]
-    assert get_target_slack_user_ids(command_string) == expected
+    assert get_user_ids_from_command(command_string) == expected
+
+
+def test_get_quote_content_from_remember_command_returns_content_on_valid_command(client, session):
+    mock_content = mixer.faker.sentence()
+    command_string = f'remember that <@U123> said "{mock_content}"'
+    assert get_quote_content_from_remember_command(command_string) == mock_content


### PR DESCRIPTION
# Overview
This PR implements the **remember** Action. This Action is used to store Quotes into a Person's memory.

## Terminology
- A **Command** is the string a Slack user enters to invoke an NB Action
- An **Action** is a method that NB can perform (e.g. remember, remind me, etc.)

## Technical Details
- The remember Action can currently only be invoked using the following _valid_ Command form:
```
remember that @user said "<quote>"
```
  - Note that the quote must be enclosed by double quotes!

### Actions
- `run_action()` determines the most applicable Action to perform based on parsing an input Command
- Each Action will need an **Action matching function**, which parses input Commands and returns `True` if the Command invokes the Action in consideration
- NB Actions return a **standardized payload container: `Result`**
  - This allows Actions to return a bool status for internal conditions, and a message to output back onto the Slack channel

### Bot `slack_user_id`
- The SlackBot's `slack_user_id` is _necessary_ for ensuring the correctness of `is_remember_action()`
  - `run_action()` checks if > 1 target slack user id is present in the command
  - But it filters out the SlackBot's own `slack_user_id`
  - If there's none initialized, then this check will fail, since > 1 `slack_user_ids` will show up
- Use the `get_bot_slack_user_id()` as the primary interface for getting the slack user id (instead of accessing the attribute directly)
  - This getter method checks if the attribute is initialized, and if not, does a fetch to Slack to get it


# TODO
- [x] Have a setup method for slackbot unit tests that standardizes the `slack_user_id` for the bot
  - Right now, `test_init_bot_slack_user_id()` sets the `bot`'s `slack_user_id` to something arbitrary
  - **The `is_remember_action()` tests currently rely on the `bot.slack_user_id` to be accurate**
- [x] Implement the method that actually executes the action in the bot