### PR TITLE
Add Remind feature

### DIFF
--- a/nb2/service/dtos.py
+++ b/nb2/service/dtos.py
@@ -25,7 +25,7 @@ class CreatePersonDTO(BaseDTO):
     Data transfer object for adding a Person to the db.
 
     Required Fields:
-        slack_user_id: string representing the Person's primary Slack id.
+        slack_user_id: String representing the unique Slack identifier for a Person.
         first_name: string representing Person's first name.
     """
 
@@ -42,7 +42,7 @@ class AddQuoteDTO(BaseDTO):
     Data transfer object for adding a Quote to a Person.
 
     Required Fields:
-        slack_user_id: string representing the Person's primary Slack id.
+        slack_user_id: String representing the unique Slack identifier for a Person.
         content: string representing a Quote the Person has said.
     """
 

--- a/nb2/service/person_service.py
+++ b/nb2/service/person_service.py
@@ -20,13 +20,30 @@ def get_person_by_slack_user_id(slack_user_id: str):
     Return Person with slack_user_id if it exists.
 
     Required Args:
-        slack_user_id: string representing the Person's primary Slack id.
+        slack_user_id: String representing the unique Slack identifier for a Person.
 
     Returns:
         Person object if one exists in the db with slack_user_id
         None if no such person exists.
     """
     return Person.query.filter_by(slack_user_id=slack_user_id).one_or_none()
+
+
+def get_person_name_by_slack_user_id(slack_user_id: str):
+    """
+    Return Person's name with slack_user_id if it exists.
+
+    Required Args:
+        slack_user_id: string representing the Person's primary Slack id.
+
+    Returns:
+        If the Person with slack_user_id exists in the db return
+        their first name as a string, otherwise return None.
+    """
+    person = Person.query.filter_by(slack_user_id=slack_user_id).one_or_none()
+
+    if person is not None:
+        return person.first_name
 
 
 def create_person(data: CreatePersonDTO):
@@ -49,9 +66,7 @@ def create_person(data: CreatePersonDTO):
         )
 
     new_person = Person(
-        slack_user_id=data.slack_user_id,
-        first_name=data.first_name,
-        last_name=data.last_name
+        slack_user_id=data.slack_user_id, first_name=data.first_name, last_name=data.last_name
     )
 
     db.session.add(new_person)

--- a/nb2/service/quote_service.py
+++ b/nb2/service/quote_service.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from sqlalchemy.sql.expression import func
 
 from nb2 import db
@@ -15,7 +17,7 @@ def get_quote_from_person(slack_user_id: str, quote_id: int):
     Get a Quote from a Person.
 
     Required Args:
-        slack_user_id: The unique Slack identifier for a Person.
+        slack_user_id: String representing the unique Slack identifier for a Person.
         quote_id: The primary key of a Quote.
 
     Returns:
@@ -29,12 +31,12 @@ def get_quote_from_person(slack_user_id: str, quote_id: int):
     )
 
 
-def get_random_quote_from_person(slack_user_id: str, num_quotes: int = 1):
+def get_random_quotes_from_person(slack_user_id: str, num_quotes: int = 1) -> List[Quote]:
     """
-    Get a <num_quotes> Quote(s) from a Person.
+    Get <num_quotes> random Quote(s) from a Person.
 
     Required Args:
-        slack_user_id: The unique Slack identifier for a Person.
+        slack_user_id: String representing the unique Slack identifier for a Person.
         num_quotes: The number of random quotes to receive (defaults to 1).
 
     Returns:
@@ -44,7 +46,7 @@ def get_random_quote_from_person(slack_user_id: str, num_quotes: int = 1):
         Quote.query.order_by(func.random())
         .join(Person)
         .filter(Person.slack_user_id == slack_user_id)
-        .limit(1)
+        .limit(num_quotes)
         .all()
     )
 
@@ -54,7 +56,7 @@ def get_all_quotes_from_person(slack_user_id: str):
     Get all Quote from a Person.
 
     Required Args:
-        slack_user_id: The unique Slack identifier for a Person.
+        slack_user_id: String representing the unique Slack identifier for a Person.
 
     Returns:
         A list of Quote objects.

--- a/nb2/service/slack_service.py
+++ b/nb2/service/slack_service.py
@@ -23,6 +23,24 @@ def get_user_ids_from_command(command: str) -> [str]:
     return [user_id.group() for user_id in re.finditer(slack_user_id_pattern, command)]
 
 
+def mention_users(slack_user_ids: [str]) -> [str]:
+    """
+    Add the required tokens to each slack_user_id so that the corresponding users
+    will be pinged in a slack message.
+
+    e.g.
+    ["u1", "u2"] -> "<@u1> <@u2>"
+
+    Args:
+        - slack_user_ids: list of strings representing slack user ids.
+
+    Returns:
+        A string that can be added to a slack message to ping users.
+    """
+
+    return " ".join([f"<@{user_id}>" for user_id in slack_user_ids])
+
+
 def get_quote_content_from_remember_command(command: str) -> str:
     """
     Parse a command string invoking a "remember" Action and return the content for the

--- a/tests/service/test_quote_service.py
+++ b/tests/service/test_quote_service.py
@@ -12,7 +12,7 @@ from nb2.service.quote_service import (
     add_quote_to_person,
     get_all_quotes_from_person,
     get_quote_from_person,
-    get_random_quote_from_person,
+    get_random_quotes_from_person,
 )
 
 
@@ -25,13 +25,25 @@ def test_get_quote_from_person(client, session):
     assert actual_quote == expected_quote
 
 
-def test_get_random_quote_from_person(client, session):
+@pytest.mark.parametrize("num_quotes", [0, 1, 5])
+def test_get_random_quotes_from_person(client, session, num_quotes):
     person = mixer.blend(Person)
-    expected_quote = mixer.blend(Quote, person=person)
+    expected_quotes = mixer.cycle().blend(Quote, person=person)
 
-    random_quote = get_random_quote_from_person(person.slack_user_id)[0]
+    random_quotes = get_random_quotes_from_person(person.slack_user_id, num_quotes)
 
-    assert random_quote == expected_quote
+    assert set(random_quotes).issubset(expected_quotes)
+    assert len(random_quotes) == num_quotes
+
+
+def test_get_random_quotes_from_person_defaults_to_one(client, session):
+    person = mixer.blend(Person)
+    expected_quotes = mixer.cycle().blend(Quote, person=person)
+
+    random_quotes = get_random_quotes_from_person(person.slack_user_id)
+
+    assert set(random_quotes).issubset(expected_quotes)
+    assert len(random_quotes) == 1
 
 
 @pytest.mark.parametrize("num_quotes", [0, 1, 5])

--- a/tests/service/test_slack_service.py
+++ b/tests/service/test_slack_service.py
@@ -3,6 +3,7 @@ from mixer.backend.flask import mixer
 from nb2.service.slack_service import (
     get_quote_content_from_remember_command,
     get_user_ids_from_command,
+    mention_users,
 )
 
 
@@ -16,3 +17,12 @@ def test_get_quote_content_from_remember_command_returns_content_on_valid_comman
     mock_content = mixer.faker.sentence()
     command_string = f'remember that <@U123> said "{mock_content}"'
     assert get_quote_content_from_remember_command(command_string) == mock_content
+
+
+def test_mention_users_add_mention_tokens(client, session):
+    user_ids = ["abc", "123"]
+    expected = "<@abc> <@123>"
+
+    result = mention_users(user_ids)
+
+    assert result == expected


### PR DESCRIPTION
## Overview 

- Some minor refactoring of `run_action` to remove all references to the slack bot in the command

- Added a check for whether the command matches the expected format for remind

- Added the actual remind command that looks up whether the person exists and returns a random quote for that person. Otherwise respond to say that the bot doesn't remember the person.

- Update the Person service to just get the first name of a person.

- Update the Quote service to return a random quote.

## TODO
- [x] Write tests

resolves #20