### PR TITLE
Fix duplicate quote exception

### DIFF
--- a/nb2/bot/slack_bot.py
+++ b/nb2/bot/slack_bot.py
@@ -5,6 +5,7 @@ from typing import List
 from slack import WebClient
 
 from nb2.service.dtos import AddQuoteDTO, CreatePersonDTO
+from nb2.service.exceptions import QuoteAlreadyExistsException
 from nb2.service.person_service import (
     create_person,
     get_person_by_slack_user_id,
@@ -155,7 +156,10 @@ class SlackBot:
 
         add_quote_dto = AddQuoteDTO(slack_user_id=target_slack_user_id, content=quote)
 
-        add_quote_to_person(add_quote_dto)
+        try:
+            add_quote_to_person(add_quote_dto)
+        except QuoteAlreadyExistsException:
+            return self.Result(ok=True, message="This quote already exists.")
 
         return self.Result(ok=True, message="Memory stored!")
 

--- a/tests/bot/test_slackbot.py
+++ b/tests/bot/test_slackbot.py
@@ -163,6 +163,27 @@ def test_remember_adds_quote_to_existing_person(client, session, mock_bot):
     assert new_person.quotes[0].content == mock_quote
 
 
+def test_remember_responds_with_message_for_duplicate_quotes(client, session, mock_bot):
+    expected_message = "This quote already exists."
+    mock_slack_user_id = mixer.faker.pystr(10)
+    mock_first_name = mixer.faker.first_name()
+    mock_last_name = mixer.faker.last_name()
+    mock_quote = mixer.faker.sentence()
+
+    person = Person(
+        slack_user_id=mock_slack_user_id, first_name=mock_first_name, last_name=mock_last_name
+    )
+    session.add(person)
+    session.commit()
+    quote = Quote(content=mock_quote, person_id=person.id)
+    session.add(quote)
+    session.commit()
+
+    response = mock_bot.remember(mock_slack_user_id, mock_quote)
+
+    assert response.message == expected_message
+
+
 def test_remind_gets_a_random_quote_for_person(client, session, mock_bot):
     mock_nostalgia_person = mixer.blend(Person)
     mock_target_person = mixer.blend(Person)


### PR DESCRIPTION
We raise an exception in the quote service when a duplicate quote is added to the user. This exception bubbles up to the bot without being caught and results in the bot failing. 

This MR fixes the issue, by adding a `try/except` to send a message to the user when this happens to let them know the quote already exists.

resolves #72